### PR TITLE
Fix breakage with the latest Plone Security Hotfix

### DIFF
--- a/Products/PloneFormGen/skins/PloneFormGen/fg_edit_macros_p3.pt
+++ b/Products/PloneFormGen/skins/PloneFormGen/fg_edit_macros_p3.pt
@@ -180,15 +180,17 @@
               Turn 'persistent_' variables from forms (GET/POST) persistent
             </tal:comment>
             <tal:env repeat="env request/form">
-              <input type="hidden"
-                     name="key"
-                     value="value"
-                     tal:define="key env;
-                                 value request/?env"
-                     tal:condition="python:key.startswith('persistent_')"
-                     tal:attributes="name string:form_env.${key}:record;
-                                     value value"
-                     />
+              <tal:block define="key env"
+                         condition="python: not key.startswith('_')">
+                <input type="hidden"
+                       name="key"
+                       value="value"
+                       tal:define="value request/?env"
+                       tal:condition="python:key.startswith('persistent_')"
+                       tal:attributes="name string:form_env.${key}:record;
+                                       value value"
+                       />
+              </tal:block>
             </tal:env>
 
             <tal:comment replace="nothing">


### PR DESCRIPTION
With the latest plone security hotfix (Products.PloneHotfix20210518), traversal to names starting with _ is forbidden.
As we do only want names starting with persistent_ here, we can safely ignore anything starting with _ and do not try to get it from the request.